### PR TITLE
Update GeoSettingsActivity.java

### DIFF
--- a/app/src/main/java/nl/hnogames/domoticz/GeoSettingsActivity.java
+++ b/app/src/main/java/nl/hnogames/domoticz/GeoSettingsActivity.java
@@ -208,6 +208,7 @@ public class GeoSettingsActivity extends AppCompatActivity implements OnPermissi
                             adapter.notifyDataSetChanged();
                         }
                     }
+                }  
                 else {   
                     mSharedPrefs.updateLocation(selectedLocation);
                     adapter.data = mSharedPrefs.getLocations();

--- a/app/src/main/java/nl/hnogames/domoticz/GeoSettingsActivity.java
+++ b/app/src/main/java/nl/hnogames/domoticz/GeoSettingsActivity.java
@@ -198,14 +198,20 @@ public class GeoSettingsActivity extends AppCompatActivity implements OnPermissi
                 selectedLocation.setSwitchName(selectedSwitchName);
                 selectedLocation.setSceneOrGroup(isSceneOrGroup);
 
-                for (DevicesInfo s : supportedSwitches) {
-                    if (s.getIdx() == selectedSwitchIDX && s.getSwitchTypeVal() == DomoticzValues.Device.Type.Value.SELECTOR)
-                        showSelectorDialog(selectedLocation, s);
-                    else {
-                        mSharedPrefs.updateLocation(selectedLocation);
-                        adapter.data = mSharedPrefs.getLocations();
-                        adapter.notifyDataSetChanged();
+                if (!isSceneOrGroup) {
+                    for (DevicesInfo s : supportedSwitches) {
+                        if (s.getIdx() == selectedSwitchIDX && s.getSwitchTypeVal() == DomoticzValues.Device.Type.Value.SELECTOR)
+                            showSelectorDialog(selectedLocation, s);
+                        else {
+                            mSharedPrefs.updateLocation(selectedLocation);
+                            adapter.data = mSharedPrefs.getLocations();
+                            adapter.notifyDataSetChanged();
+                        }
                     }
+                else {   
+                    mSharedPrefs.updateLocation(selectedLocation);
+                    adapter.data = mSharedPrefs.getLocations();
+                    adapter.notifyDataSetChanged();
                 }
             }
         });


### PR DESCRIPTION
Probable fix for #427.
If a scene was selected, the for loop going through switches is not applicable, and program will fail to select scene if there is no matching switch-Id to the group Id.

See also fix for NFC (jvaassen-patch-1).